### PR TITLE
Dockerfile: Add Dockerfile and its build workflow

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -1,0 +1,27 @@
+# Workflow that tests the validity of the DockerFile
+name: Docker Image Build
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'tests/requirements.txt'
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'Dockerfile'
+      - 'tests/requirements.txt'
+
+jobs:
+  build-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v3
+      with:
+        path: wifi-power-meas-test
+        fetch-depth: 0
+
+    - name: Build the Docker image
+      working-directory: wifi-power-meas-test
+      run: docker build . --file Dockerfile --tag wifi-power-meas-test:test
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Start with the Zephyr CI image
+FROM ghcr.io/zephyrproject-rtos/ci:v0.26.2
+WORKDIR /workdir
+
+ARG NORDIC_COMMAND_LINE_TOOLS_VERSION="Versions-10-x-x/10-17-0/nrf-command-line-tools-10.17.0"
+
+# Copy the requirements.txt file to the container
+COPY tests/requirements.txt .
+
+# Install the Python modules specified in requirements.txt
+RUN pip install -r requirements.txt
+
+# Remove the requirements.txt file
+RUN rm requirements.txt
+
+RUN echo "Installing dependencies for nRFCommand line tools" && \
+    apt-get update && \
+    apt-get install libxcb-render-util0-dev -y && \
+    apt-get install libxrender1 libxcb-shape0 libxcb-randr0 libxcb-icccm4 libxcb-keysyms1 libxcb-image0 libxkbcommon-x11-0 -y
+
+# Nordic command line tools
+ARG NCLT_URL="https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/${NORDIC_COMMAND_LINE_TOOLS_VERSION}_Linux-amd64.tar.gz"
+RUN echo "NCLT_URL=${NCLT_URL}" && \
+    mkdir tmp && cd tmp && \
+    wget -qO - "${NCLT_URL}" | tar --no-same-owner -xz && \
+    # Install included JLink
+    DEBIAN_FRONTEND=noninteractive apt-get -y install ./*.deb && \
+    # Install nrf-command-line-tools
+    cp -r ./nrf-command-line-tools /opt && \
+    ln -s /opt/nrf-command-line-tools/bin/nrfjprog /usr/local/bin/nrfjprog && \
+    ln -s /opt/nrf-command-line-tools/bin/mergehex /usr/local/bin/mergehex && \
+    cd .. && rm -rf tmp


### PR DESCRIPTION
Add Dockerfile that is intended to build a docker image used by this repo.
Added a build workflow that is intended to ensure that any changes to Dockerfile and requirements.txt continues to build.