### PR TITLE
Fix: Trigger docker publish workflow on tags

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,7 +1,8 @@
 name: Docker Image Build and publish
 on:
   push:
-    branches: [ "release" ]
+    tags:
+        - 'v*'
 
 jobs:
   build-docker-image:


### PR DESCRIPTION
It now triggers on all pushes to all tags